### PR TITLE
[Mozilla Branding Removal] Update dependency links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oveddan-behave-graph/core": "^0.11.1"
       },
       "devDependencies": {
-        "@types/hubs": "github:MozillaReality/hubs-ts-types#main",
+        "@types/hubs": "github:Hubs-Foundation/hubs-ts-types#main",
         "@types/node": "^18.15.0",
         "@types/react": "^18.2.57",
         "@types/three": "^0.141.0",
@@ -22,10 +22,10 @@
         "webpack-cli": "^5.1.4"
       },
       "peerDependencies": {
-        "aframe": "github:mozillareality/aframe#hubs/master",
-        "bitecs": "github:mozilla/bitECS#hubs-patches",
+        "aframe": "github:Hubs-Foundation/aframe#hubs/master",
+        "bitecs": "github:Hubs-Foundation/bitECS#hubs-patches",
         "react": "^18.2.0",
-        "three": "github:mozillareality/three.js#65b5105908f5f135cad25fed07e25f15f3876777",
+        "three": "github:Hubs-Foundation/three.js#65b5105908f5f135cad25fed07e25f15f3876777",
         "troika-three-text": "^0.45.0"
       }
     },
@@ -172,18 +172,18 @@
     },
     "node_modules/@types/hubs": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/MozillaReality/hubs-ts-types.git#d9f56d541f3cf6b8fd360ae96652bf47941f8894",
+      "resolved": "git+ssh://git@github.com/Hubs-Foundation/hubs-ts-types.git#d9f56d541f3cf6b8fd360ae96652bf47941f8894",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@formatjs/intl-locale": "^2.4.13",
         "@types/react": "^18.2.0",
         "@types/three": "^0.141.0",
-        "aframe": "github:mozillareality/aframe#hubs/master",
-        "bitecs": "github:mozilla/bitECS#hubs-patches",
+        "aframe": "github:Hubs-Foundation/aframe#hubs/master",
+        "bitecs": "github:Hubs-Foundation/bitECS#hubs-patches",
         "event-target-shim": "^3.0.1",
         "eventemitter3": "^4.0.3",
-        "networked-aframe": "github:mozillareality/networked-aframe#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
+        "networked-aframe": "github:Hubs-Foundation/networked-aframe#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
         "postprocessing": "^6.28.7",
         "troika-three-text": "^0.45.0"
       }
@@ -482,7 +482,7 @@
     },
     "node_modules/aframe": {
       "version": "1.0.3",
-      "resolved": "git+ssh://git@github.com/mozillareality/aframe.git#0fa14187b8f3e90726385904591eba799380df79",
+      "resolved": "git+ssh://git@github.com/Hubs-Foundation/aframe.git#0fa14187b8f3e90726385904591eba799380df79",
       "license": "MIT",
       "dependencies": {
         "custom-event-polyfill": "^1.0.6",
@@ -538,7 +538,7 @@
     },
     "node_modules/bitecs": {
       "version": "0.3.38",
-      "resolved": "git+ssh://git@github.com/mozilla/bitECS.git#913b4ae261684eee205251e41a3250d1c1a2817e",
+      "resolved": "git+ssh://git@github.com/Hubs-Foundation/bitECS.git#913b4ae261684eee205251e41a3250d1c1a2817e",
       "license": "MPL-2.0"
     },
     "node_modules/braces": {
@@ -1182,7 +1182,7 @@
     },
     "node_modules/networked-aframe": {
       "version": "0.6.1",
-      "resolved": "git+ssh://git@github.com/mozillareality/networked-aframe.git#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
+      "resolved": "git+ssh://git@github.com/Hubs-Foundation/networked-aframe.git#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
       "integrity": "sha512-T8wzMgtLYuFqWRx2cTxadNzDECir2x2gdJlV4TQTAwpZALo0PKyPie5VX3rjEIL9l4/5N3yK+dCtRW70NuUfhg==",
       "dev": true,
       "license": "MIT",
@@ -1620,7 +1620,7 @@
     },
     "node_modules/three": {
       "version": "0.141.0",
-      "resolved": "git+ssh://git@github.com/mozillareality/three.js.git#65b5105908f5f135cad25fed07e25f15f3876777",
+      "resolved": "git+ssh://git@github.com/Hubs-Foundation/three.js.git#65b5105908f5f135cad25fed07e25f15f3876777",
       "integrity": "sha512-J6jMBkLHP+YqHHEHsn5iFBTbrhzw8yrO4ZqD0gQM3RrchgG0h6ZZp3XW90IwvrNqRDI2YBTys50d3JsPF5pJEg==",
       "license": "MIT",
       "peer": true
@@ -2067,18 +2067,18 @@
       "dev": true
     },
     "@types/hubs": {
-      "version": "git+ssh://git@github.com/MozillaReality/hubs-ts-types.git#d9f56d541f3cf6b8fd360ae96652bf47941f8894",
+      "version": "git+ssh://git@github.com/Hubs-Foundation/hubs-ts-types.git#d9f56d541f3cf6b8fd360ae96652bf47941f8894",
       "dev": true,
-      "from": "@types/hubs@github:MozillaReality/hubs-ts-types#main",
+      "from": "@types/hubs@github:Hubs-Foundation/hubs-ts-types#main",
       "requires": {
         "@formatjs/intl-locale": "^2.4.13",
         "@types/react": "^18.2.0",
         "@types/three": "^0.141.0",
-        "aframe": "github:mozillareality/aframe#hubs/master",
-        "bitecs": "github:mozilla/bitECS#hubs-patches",
+        "aframe": "github:Hubs-Foundation/aframe#hubs/master",
+        "bitecs": "github:Hubs-Foundation/bitECS#hubs-patches",
         "event-target-shim": "^3.0.1",
         "eventemitter3": "^4.0.3",
-        "networked-aframe": "github:mozillareality/networked-aframe#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
+        "networked-aframe": "github:Hubs-Foundation/networked-aframe#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
         "postprocessing": "^6.28.7",
         "troika-three-text": "^0.45.0"
       },
@@ -2335,8 +2335,8 @@
       "requires": {}
     },
     "aframe": {
-      "version": "git+ssh://git@github.com/mozillareality/aframe.git#0fa14187b8f3e90726385904591eba799380df79",
-      "from": "aframe@github:mozillareality/aframe#hubs/master",
+      "version": "git+ssh://git@github.com/Hubs-Foundation/aframe.git#0fa14187b8f3e90726385904591eba799380df79",
+      "from": "aframe@github:Hubs-Foundation/aframe#hubs/master",
       "requires": {
         "custom-event-polyfill": "^1.0.6",
         "debug": "ngokevin/debug#noTimestamp",
@@ -2375,8 +2375,8 @@
       }
     },
     "bitecs": {
-      "version": "git+ssh://git@github.com/mozilla/bitECS.git#913b4ae261684eee205251e41a3250d1c1a2817e",
-      "from": "bitecs@github:mozilla/bitECS#hubs-patches"
+      "version": "git+ssh://git@github.com/Hubs-Foundation/bitECS.git#913b4ae261684eee205251e41a3250d1c1a2817e",
+      "from": "bitecs@github:Hubs-Foundation/bitECS#hubs-patches"
     },
     "braces": {
       "version": "3.0.2",
@@ -2832,10 +2832,10 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "git+ssh://git@github.com/mozillareality/networked-aframe.git#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
+      "version": "git+ssh://git@github.com/Hubs-Foundation/networked-aframe.git#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
       "integrity": "sha512-T8wzMgtLYuFqWRx2cTxadNzDECir2x2gdJlV4TQTAwpZALo0PKyPie5VX3rjEIL9l4/5N3yK+dCtRW70NuUfhg==",
       "dev": true,
-      "from": "networked-aframe@github:mozillareality/networked-aframe#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
+      "from": "networked-aframe@github:Hubs-Foundation/networked-aframe#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
       "requires": {
         "buffered-interpolation": "github:Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b"
       }
@@ -3120,9 +3120,9 @@
       }
     },
     "three": {
-      "version": "git+ssh://git@github.com/mozillareality/three.js.git#65b5105908f5f135cad25fed07e25f15f3876777",
+      "version": "git+ssh://git@github.com/Hubs-Foundation/three.js.git#65b5105908f5f135cad25fed07e25f15f3876777",
       "integrity": "sha512-J6jMBkLHP+YqHHEHsn5iFBTbrhzw8yrO4ZqD0gQM3RrchgG0h6ZZp3XW90IwvrNqRDI2YBTys50d3JsPF5pJEg==",
-      "from": "three@github:mozillareality/three.js#65b5105908f5f135cad25fed07e25f15f3876777",
+      "from": "three@github:Hubs-Foundation/three.js#65b5105908f5f135cad25fed07e25f15f3876777",
       "peer": true
     },
     "three-stdlib": {

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   "type": "module",
   "module": "dist/index.mjs",
   "peerDependencies": {
-    "aframe": "github:mozillareality/aframe#hubs/master",
-    "bitecs": "github:mozilla/bitECS#hubs-patches",
+    "aframe": "github:Hubs-Foundation/aframe#hubs/master",
+    "bitecs": "github:Hubs-Foundation/bitECS#hubs-patches",
     "react": "^18.2.0",
-    "three": "github:mozillareality/three.js#65b5105908f5f135cad25fed07e25f15f3876777",
+    "three": "github:Hubs-Foundation/three.js#65b5105908f5f135cad25fed07e25f15f3876777",
     "troika-three-text": "^0.45.0"
   },
   "devDependencies": {
-    "@types/hubs": "github:MozillaReality/hubs-ts-types#main",
+    "@types/hubs": "github:Hubs-Foundation/hubs-ts-types#main",
     "@types/node": "^18.15.0",
     "@types/react": "^18.2.57",
     "@types/three": "^0.141.0",


### PR DESCRIPTION
Update the links in package.json and package-lock.json to point to the new Hubs Foundation URLs.

This also fixes conflicts when fetching the repository as a dependency of the addons branch for the Hubs client.